### PR TITLE
Version 1.5.0

### DIFF
--- a/TabExtract.js
+++ b/TabExtract.js
@@ -1,6 +1,27 @@
 (function() {
 
   var matches = function( keywords, tab ) {
+    // Check if this is a Marvellous Suspender suspended tab
+    const suspenderPrefix = "chrome-extension://noogafoofpebimajpfpamcfhoaifemoa/suspended.html";
+    if (tab.url.startsWith(suspenderPrefix)) {
+      // Extract the original URL and title from the suspended tab URL
+      try {
+        const hashParams = new URL(tab.url).hash.substring(1);
+        const params = new URLSearchParams(hashParams);
+        const originalUrl = params.get('uri') || '';
+        const originalTitle = decodeURIComponent(params.get('ttl') || '');
+        
+        // Search in the original URL and title
+        for(var i = 0; i < keywords.length; i++) {
+          if( originalUrl.toLowerCase().search(keywords[i]) > -1 ) { return true; }
+          if( originalTitle.toLowerCase().search(keywords[i]) > -1 ) { return true; }
+        }
+      } catch (e) {
+        // If parsing fails, fall back to normal matching
+      }
+    }
+    
+    // Normal matching for non-suspended tabs
     for(var i = 0; i < keywords.length; i++) {
       if( (tab.url.toLowerCase()).search(keywords[i]) > -1 ) { return true; }
       if( (tab.title.toLowerCase()).search(keywords[i]) > -1 ) { return true; }
@@ -11,8 +32,6 @@
   var getMatchingTabs = function( text, callback ) {
     var matchingTabs = [];
     var queryInfo = {
-      pinned: false,
-      status: "complete",
       windowType: "normal"
     };
     chrome.tabs.query( queryInfo, function( tabs ) {
@@ -22,16 +41,20 @@
       }
       for(var i = 0; i < tabs.length; i++) {
         if( matches( keywords, tabs[i] ) ) {
-          matchingTabs.push( tabs[i].id );
+          matchingTabs.push( tabs[i] );
         }
       }
       callback( matchingTabs );
     } );
   };
 
+  var getPinnedTabIDs = function(tabs) {
+    return tabs.filter(t => t.pinned).map(t => t.id);
+  }
+
   chrome.omnibox.onInputChanged.addListener( function( text, suggest ) {
     getMatchingTabs( text, function( matchingTabs ) {
-
+      var pinnedTabIDs = getPinnedTabIDs(matchingTabs);
       var suggestionText = (matchingTabs.length < 1) ? 
         "0 tabs matching. Enter another keyword or press ESC to cancel."
         : matchingTabs.length + " tabs matching. Press enter to move them to a new window.";
@@ -44,15 +67,19 @@
     getMatchingTabs( text, function( matchingTabs ) {
 
       if( matchingTabs.length < 1 || text === "" ) {
-        alert(
-          'no matches found for the keywords "' + text + '".'
-          + "\nNote: You do not need to press down to select a suggestion. Just press enter after entering keywords."
-        );
+        // Do nothing - the omnibox already shows "0 tabs matching" as feedback
+        return;
       }
       else {
         chrome.windows.create( {type: "normal"}, function( win ) {
           var newWindow = win;
-          chrome.tabs.move( matchingTabs, { windowId: newWindow.id, index: -1 } );
+          const pinnedTabIDs = getPinnedTabIDs(matchingTabs)
+
+          chrome.tabs.move( matchingTabs.map(t => t.id), { windowId: newWindow.id, index: -1 }, function() {
+            pinnedTabIDs.forEach(function(id) {
+              chrome.tabs.update(id, {pinned: true});
+            });
+          } );
           chrome.tabs.remove( newWindow.tabs[newWindow.tabs.length - 1].id );
         } );
       }

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,14 @@
 {
+"update_url": "https://clients2.google.com/service/update2/crx",
+
   "name": "Tab Extract",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "A simple & lightweight tool to reduce tab clutter, using just the address bar.",
-  "minimum_chrome_version" : "9.0.0.0",
-  "manifest_version": 2,
+  "minimum_chrome_version" : "88.0.0.0",
+  "manifest_version": 3,
   "omnibox": { "keyword" : "ex" },
   "background": {
-    "scripts": ["TabExtract.js"],
-    "persistent": false
+    "service_worker": "TabExtract.js"
   },
   "icons" : {
     "16" : "icon_016.png",


### PR DESCRIPTION
- Migrated from Chrome Extension Manifest v2 to Manifest v3
  - Background script now runs as a service worker
  - Updated minimum Chrome version to 88
  - Removed alert() for service worker compatibility (omnibox already provides feedback)

- Support for Marvellous Suspender suspended tabs
  - Extension now searches within the original URL and title of suspended tabs
  - Suspended tabs are moved while maintaining their suspended state
- Support for Chrome's natively unloaded tabs
  - Removed status filter to include tabs in all loading states
  - Fixes issue where unloaded tabs were not being found

- Fixed compatibility with modern Chrome versions that use tab unloading for memory management